### PR TITLE
Annotate Gemini KDA rubric leak

### DIFF
--- a/benchmarks/hard/results/annotations/20260613_101539_gemini_gemini-3.5-flash_02_kda_cutlass.yaml
+++ b/benchmarks/hard/results/annotations/20260613_101539_gemini_gemini-3.5-flash_02_kda_cutlass.yaml
@@ -1,0 +1,21 @@
+run_id: 20260613_101539_gemini_gemini-3.5-flash_02_kda_cutlass
+model: gemini-3.5-flash
+harness: gemini
+effort: ""
+problem: 02_kda_cutlass
+peak_fraction: 0.0062
+
+verdict: rubric_leak
+
+summary: "Passing KDA cell, but not a fully custom-kernel implementation: the recurrence is a real Triton kernel, while the intra-chunk phase is wrapped in torch.compile and uses PyTorch matmul / @ / triu / eye tensor ops for A, w, u, and Aqk. This does not call the explicitly forbidden FLA KDA implementations and is not output memoization or judge tampering, but it slips through because 02_kda_cutlass only forbids named FLA entrypoints rather than generic PyTorch matmul decomposition. Keep valid under current rules, but flag as a custom-kernel mandate leak."
+
+quotes:
+  - file: solution.py
+    lines: [102, 170]
+    label: "PyTorch/Inductor intra-chunk path"
+    text: "@torch.compile(mode=\"reduce-overhead\", fullgraph=True) ... A = torch.matmul(...) ... w = A_final @ ... u = A_final @ v ... Aqk = torch.matmul(...)"
+
+implication: |
+  If Hard wants this problem to require custom kernels for the full KDA forward,
+  the forbidden list should include torch.matmul / torch.bmm / torch.compile
+  for 02_kda_cutlass or check.py should enforce framework coverage more strictly.

--- a/benchmarks/hard/results/leaderboard.json
+++ b/benchmarks/hard/results/leaderboard.json
@@ -193,7 +193,8 @@
           "correct": true,
           "has_solution": true,
           "peak_fraction": 0.006200000000000001,
-          "elapsed_seconds": 5190
+          "elapsed_seconds": 5190,
+          "annotation_verdict": "rubric_leak"
         },
         "03_paged_attention": {
           "run_id": "20260613_105439_gemini_gemini-3.5-flash_03_paged_attention",

--- a/benchmarks/hard/results/leaderboard_v2.json
+++ b/benchmarks/hard/results/leaderboard_v2.json
@@ -194,7 +194,8 @@
           "correct": true,
           "has_solution": true,
           "peak_fraction": 0.006200000000000001,
-          "elapsed_seconds": 5190
+          "elapsed_seconds": 5190,
+          "annotation_verdict": "rubric_leak"
         },
         "03_paged_attention": {
           "run_id": "20260613_105439_gemini_gemini-3.5-flash_03_paged_attention",
@@ -577,7 +578,7 @@
         {
           "model": "gemini/gemini-3.5-flash",
           "peak_fraction": 0.006200000000000001,
-          "verdict": null
+          "verdict": "rubric_leak"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- annotate `gemini/gemini-3.5-flash` on `02_kda_cutlass` as `rubric_leak`
- flag that the passing KDA cell uses PyTorch/Inductor matmul decomposition for the intra-chunk phase, while only the recurrence is a custom Triton kernel
- refresh `leaderboard.json` and `leaderboard_v2.json` so the site data carries the annotation

## Verification
- `uv run python` JSON parse/assertion check for both leaderboard files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark metadata and leaderboard JSON only; no grader, harness, or solution code changes.
> 
> **Overview**
> Adds a run annotation for **gemini/gemini-3.5-flash** on **02_kda_cutlass** with verdict **`rubric_leak`**, documenting that the pass uses a Triton recurrence but leans on **`torch.compile`** and PyTorch **`matmul`** for the intra-chunk phase—valid under today’s forbidden-FLA rules but not a full custom-kernel KDA forward.
> 
> **`leaderboard.json`** and **`leaderboard_v2.json`** now carry **`annotation_verdict`: `rubric_leak`** on that cell (and the v2 **`02_kda_cutlass`** ranked pass entry for Gemini), so published site data surfaces the caveat alongside the peak score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eaa2c8bf6e9bce1b3724ac3f2cc1a239d835891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->